### PR TITLE
Fix path resources extraction

### DIFF
--- a/WorkbenchUtilities/Tests/Resources.mt
+++ b/WorkbenchUtilities/Tests/Resources.mt
@@ -237,6 +237,21 @@ Do[
 		With[
 			{resourcesFile = getMRPath[]}
 			,
+			Test[
+				Resources[
+					"ResourcesFile" -> resourcesFile
+				]@resource
+				,
+				{}
+				,
+				TestID -> "Paths: no element",
+				TestFailureMessage -> ToString[resource]
+			]
+		];
+		
+		With[
+			{resourcesFile = getMRPath[]}
+			,
 			Module[
 				{wrongElement}
 				,

--- a/WorkbenchUtilities/WorkbenchUtilities.m
+++ b/WorkbenchUtilities/WorkbenchUtilities.m
@@ -185,6 +185,11 @@ Resources[args___, opts:OptionsPattern[]][
 			heldElement = Select[Hold[args], SymbolName[Head[#]] === sel &, 1]
 		}
 		,
+		If[heldElement === Hold[],
+			(* Given element not found, return epty list. *)
+			Return[{}]
+		];
+		
 		If[MemberQ[heldElement, Except[(Directory | File)[_String]], {2}],
 			Message[Resources::invalidPaths,
 				HoldForm @@ heldElement,


### PR DESCRIPTION
Handle case of no path element in Resources.
