### PR TITLE
Support v10.3

### DIFF
--- a/MultipleVersionsTests/Tests/MultipleVersionsTests/TestRunMultipleVersions.mt
+++ b/MultipleVersionsTests/Tests/MultipleVersionsTests/TestRunMultipleVersions.mt
@@ -60,7 +60,7 @@ $macrosTestSources = {
 	Hold[LogBeginTestSource, _],
 	Hold[LogTestRunProgress, 0],
 	(* Since v10.1 CharacterEncodings/PrintableASCII.m is also loaded. *)
-	If[$VersionNumber >= 10.1,
+	If[10.1 <= $VersionNumber <= 10.2,
 		{
 			Hold[LogBeginTestSource, _],
 			Hold[LogTestRunProgress, 0],

--- a/WorkbenchUtilities/WorkbenchUtilities.m
+++ b/WorkbenchUtilities/WorkbenchUtilities.m
@@ -312,10 +312,10 @@ GetMathematicaResources[dir_String /; FileType[dir] === Directory] :=
 						return empty Resources. *)
 					Return[Resources["ResourcesFile" -> resourcesFile]]
 					,
-					ReadList::nffil
+					{ReadList::nffil, ReadList::noopen}
 				]
 				,
-				ReadList::nffil
+				{ReadList::nffil, ReadList::noopen}
 			];
 			
 			resources = Cases[resources, HoldComplete[Resources[___]], {1}, 1];


### PR DESCRIPTION
* Adapt ``WorkbenchUtilities`GetMathematicaResources`` to changes in `ReadList` error reporting.
* Minor test tweaks.
